### PR TITLE
Changes in superlu solver code due to SuperLU v6.3.0 update

### DIFF
--- a/Source/Solver/solver_superlu/SolverSUPERLU.cpp
+++ b/Source/Solver/solver_superlu/SolverSUPERLU.cpp
@@ -82,8 +82,8 @@ namespace INMOST
 	  //std::cout << "M = " << m << " N = " << n << " local offset " << offset << std::endl;
 		//~ dCreate_CompRowLoc_Matrix_dist(&A_,m, n, pCSRMatrixFormat->nonzeros,local_size[0],offset,pCSRMatrixFormat->pData,pCSRMatrixFormat->pCols,pCSRMatrixFormat->pRows,SLU_NR_loc, SLU_D, SLU_GE);
 		dCreate_CompRowLoc_Matrix_dist(&(this->A),global_size, global_size, nnz,local_size,offset,a,ja,ia,SLU_NR_loc, SLU_D, SLU_GE);
-		ScalePermstructInit(global_size,global_size,&ScalePermstruct);
-		LUstructInit(global_size,&LUstruct);
+		dScalePermstructInit(global_size,global_size,&ScalePermstruct);
+		dLUstructInit(global_size,&LUstruct);
 		g_size = global_size;
 		a_size = size;
 #else //USE_SOLVER_SUPERLU_DIST
@@ -179,9 +179,9 @@ namespace INMOST
 #if defined(USE_SOLVER_SUPERLU_DIST)
 		//~ std::cout << "call clear!" << std::endl;
 		PStatFree(&stat_);
-		ScalePermstructFree(&ScalePermstruct);
-		Destroy_LU(g_size,&grid,&LUstruct);
-		LUstructFree(&LUstruct);
+		dScalePermstructFree(&ScalePermstruct);
+		dDestroy_LU(g_size,&grid,&LUstruct);
+		dLUstructFree(&LUstruct);
 		if( options_.SolveInitialized )
 		{
 			//~ std::cout << "call dSolveFinalize!" << std::endl;

--- a/Source/Solver/solver_superlu/SolverSUPERLU.h
+++ b/Source/Solver/solver_superlu/SolverSUPERLU.h
@@ -14,9 +14,9 @@ namespace INMOST {
     class SolverSUPERLU : public SolverInterface {
     private:
 #if defined(USE_SOLVER_SUPERLU_DIST)
-		LUstruct_t LUstruct;
-		SOLVEstruct_t SOLVEstruct;
-		ScalePermstruct_t ScalePermstruct;
+		dLUstruct_t LUstruct;
+		dSOLVEstruct_t SOLVEstruct;
+		dScalePermstruct_t ScalePermstruct;
 		gridinfo_t grid;
 		superlu_dist_options_t options_;
 		SuperLUStat_t stat_;


### PR DESCRIPTION
Tried to compile INMOST with SuperLU support using the following CMake command (Ubuntu 18.04 x86_64 machine):

`
cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DMPI_C_COMPILER=mpicc  -DMPI_CXX_COMPILER=mpicxx -DUSE_SOLVER_METIS=ON -DUSE_SOLVER_SUPERLU=ON -DUSE_SOLVER_SUPERLU_DOWNLOAD=ON -DUSE_PARTITIONER_PARMETIS=ON -DUSE_PARTITIONER_PARMETIS_DOWNLOAD=ON   -DCMAKE_BUILD_TYPE=Release ../INMOST
`

SuperLU and ParMETIS libraries were successfully downloaded, but INMOST build ended unsuccessfully.

This commit 
https://github.com/xiaoyeli/superlu_dist/commit/fb013e8035d2c7ca32cb58d35f90fd54518549f0
caused necessary changes in this PR to successfully compile INMOST with SuperLU.


